### PR TITLE
super unique edge case bug fix

### DIFF
--- a/bot/utils/fetchMessageHistory.js
+++ b/bot/utils/fetchMessageHistory.js
@@ -13,6 +13,7 @@ module.exports = {
 			if (last_id) options.before = last_id;
 
 			const messages = await channel.messages.fetch(options);
+			if (messages.size === 0) break;
 			sum_messages = sum_messages.concat(messages);
 			last_id = messages.last().id;
 		}


### PR DESCRIPTION
interesting case where # of messages in a channel is a multiple of 100 but n > 100, causing a break whenever the bot attempted to recover all messages in the channel